### PR TITLE
Rebuild for vtk 9.4.1 and remove dependency from vtk qt* build

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-aarch64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-aarch64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-aarch64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-aarch64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -53,13 +53,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - linux-aarch64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/migrations/vtk941.yaml
+++ b/.ci_support/migrations/vtk941.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  kind: version
+  commit_message: "Rebuild for vtk 9.4.1"
+  migration_number: 1
+migrator_ts: 1742567043.969102
+vtk_base:
+- 9.4.1
+vtk:
+- 9.4.1

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-arm64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-arm64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-arm64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-arm64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -57,13 +57,13 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - osx-arm64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5
 zip_keys:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -43,12 +43,12 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - win-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -43,12 +43,12 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - win-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -43,12 +43,12 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - win-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -43,12 +43,12 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - win-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -43,12 +43,12 @@ python:
 qhull:
 - '2020.2'
 qt6_main:
-- '6.7'
+- '6.8'
 target_platform:
 - win-64
 tbb_devel:
 - '2021'
 vtk:
-- 9.3.1
+- 9.4.1
 zeromq:
 - 4.3.5

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - fix-win-minizip.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - open3d = open3d.tools.cli:main
   ignore_run_exports_from:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,11 +69,8 @@ requirements:
     - msgpack-c
     - msgpack-cxx
     - minizip
-    - vtk * qt*
-    - qt6-main
-    # We have also a vanilla dependency of vtk without pins so that conda-smithy correctly sets the
-    # pin from conda-forge-pinnings
     - vtk
+    - qt6-main
     - libpng
     - pybind11
     - qhull
@@ -100,7 +97,6 @@ requirements:
     - python
     - plotly
     - dash
-    - vtk-base * qt*
     - libblas * *mkl  # [win]
     - minizip         # [win]
 


### PR DESCRIPTION
Fixed version of https://github.com/conda-forge/open3d-feedstock/pull/25 . 

The upgrade to vtk 9.4.1 in unified all the different build variants `vtk * osmesa*`, `vtk * egl*` and `vtk * qt*`, so there is no need (and it is not possible) to depend on the specific `qt*` build variant of vtk when migrating to vtk 9.4.1 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
