### PR TITLE
[DO NOT MERGE] Test Windows build before boost 1.88 migration

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ source:
     - fix-win-minizip.patch  # [win]
 
 build:
-  number: 4
+  skip: True  # [not win]
+  number: 5
   entry_points:
     - open3d = open3d.tools.cli:main
   ignore_run_exports_from:


### PR DESCRIPTION
To debug https://github.com/conda-forge/open3d-feedstock/pull/31 .


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
